### PR TITLE
More deployment fixes

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,5 +36,8 @@ require "capistrano/rails/migrations"
 # require "capistrano/passenger"
 require 'capistrano/postgresql'
 
+require 'capistrano/puma'
+install_plugin Capistrano::Puma
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   gem 'capistrano-postgresql',
     :git => "https://github.com/snake66/capistrano-postgresql.git",
     :branch => 'make-sudo-optional'
+  gem 'capistrano3-puma', '~> 3.1.0'
 
   # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
     capistrano-rails (1.2.3)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    capistrano3-puma (3.1.0)
+      capistrano (~> 3.7)
+      capistrano-bundler
+      puma (~> 3.4)
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -293,6 +297,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-postgresql!
   capistrano-rails
+  capistrano3-puma (~> 3.1.0)
   carrierwave (= 0.11.2)
   coffee-rails
   country_select!

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,16 +1,23 @@
 # config valid only for current version of Capistrano
 lock "3.8.1"
 
+# basic capistrano setup
 set :application, "trvguit"
 set :repo_url, "https://github.com/lakeoftearz/trvguit"
-set :deploy_to, "/home/andrea/webapps/trvguit"
+set :deploy_to, -> { "/home/#{fetch(:application)}/webapp" }
+set :tmp_dir, -> { "/home/#{fetch(:application)}/tmp" }
 
 # database settings
-set :pg_user, 'trvguit_db_admin'
+set :pg_user, -> { "#{:application}_db_admin" }
 set :pg_user_ask_for_password, true
 set :pg_system_user, 'pgsql'
 set :pg_host, ''
 set :pg_no_sudo, true
+
+# puma setup
+set :puma_user, -> { fetch(:application) }
+set :puma_daemonize, true
+append :bundle_bins, "puma", "pumactl"
 
 set :bundle_env_variables, {
   nokogiri_use_system_libraries: 1

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,4 +3,4 @@
 # Defines a single server with a list of roles and multiple properties.
 # You can define all roles on a single server, or split them:
 
-server "volse.anduin.net", user: "andrea", roles: %w{app db web}
+server "volse.anduin.net", user: "trvguit", roles: %w{app db web}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,5 +3,5 @@
 # Defines a single server with a list of roles and multiple properties.
 # You can define all roles on a single server, or split them:
 
-server "volse.local", user: "andrea", roles: %w{app db web}
+server "volse.local", user: "trvguit", roles: %w{app db web}
 set :rails_env, :production

--- a/config/deploy/templates/nginx_conf.erb
+++ b/config/deploy/templates/nginx_conf.erb
@@ -1,0 +1,82 @@
+upstream puma_<%= fetch(:nginx_config_name) %> { <%
+  @backends = [fetch(:puma_bind)].flatten.map do |m|
+  etype, address  = /(tcp|unix|ssl):\/{1,2}(.+)/.match(m).captures
+  if etype == 'unix'
+    "server #{etype}:#{address} #{fetch(:nginx_socket_flags)};"
+  else
+    "server #{address.gsub(/0\.0\.0\.0(.+)/, "127.0.0.1\\1")} #{fetch(:nginx_http_flags)};"
+  end
+end
+%><% @backends.each do |server| %>
+  <%= server %><% end %>
+}
+<% if fetch(:nginx_use_ssl) -%>
+server {
+  listen 80;
+  server_name <%= fetch(:nginx_server_name) %>;
+  rewrite ^(.*) https://$host$1 permanent;
+}
+<% end -%>
+
+server {
+<% if fetch(:nginx_use_ssl) -%>
+  listen 443;
+  ssl on;
+  ssl_certificate /etc/ssl/certs/<%= fetch(:nginx_config_name) %>.crt;
+  ssl_certificate_key /etc/ssl/private/<%= fetch(:nginx_config_name) %>.key;
+<% else -%>
+  listen 80;
+<% end -%>
+  server_name <%= fetch(:nginx_server_name) %>;
+  root <%= current_path %>/public;
+  try_files $uri/index.html $uri @puma_<%= fetch(:nginx_config_name) %>;
+
+  client_max_body_size 4G;
+  keepalive_timeout 10;
+
+  error_page 500 502 504 /500.html;
+  error_page 503 @503;
+
+  location @puma_<%= fetch(:nginx_config_name) %> {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+<% if fetch(:nginx_use_ssl) -%>
+    proxy_set_header X-Forwarded-Proto https;
+<% end -%>
+    proxy_pass http://puma_<%= fetch(:nginx_config_name) %>;
+    # limit_req zone=one;
+    access_log <%= shared_path %>/log/nginx.access.log;
+    error_log <%= shared_path %>/log/nginx.error.log;
+  }
+
+  location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+  }
+
+  location = /50x.html {
+    root html;
+  }
+
+  location = /404.html {
+    root html;
+  }
+
+  location @503 {
+    error_page 405 = /system/maintenance.html;
+    if (-f $document_root/system/maintenance.html) {
+      rewrite ^(.*)$ /system/maintenance.html break;
+    }
+    rewrite ^(.*)$ /503.html break;
+  }
+
+  if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ){
+    return 405;
+  }
+
+  if (-f $document_root/system/maintenance.html) {
+    return 503;
+  }
+}

--- a/config/deploy/templates/puma.rb.erb
+++ b/config/deploy/templates/puma.rb.erb
@@ -1,0 +1,55 @@
+#!/usr/bin/env puma
+
+# Deploy to suburl
+ENV['RAILS_RELATIVE_URL_ROOT'] = "/<%= fetch(:application) %>"
+
+directory '<%= current_path %>'
+rackup "<%=fetch(:puma_rackup)%>"
+environment '<%= fetch(:puma_env) %>'
+<% if fetch(:puma_tag) %>
+tag '<%= fetch(:puma_tag)%>'
+<% end %>
+pidfile "<%=fetch(:puma_pid)%>"
+state_path "<%=fetch(:puma_state)%>"
+stdout_redirect '<%=fetch(:puma_access_log)%>', '<%=fetch(:puma_error_log)%>', true
+
+
+threads <%=fetch(:puma_threads).join(',')%>
+
+<%= puma_plugins %>
+
+<%= puma_bind %>
+<% if fetch(:puma_control_app) %>
+activate_control_app "<%= fetch(:puma_default_control_app) %>"
+<% end %>
+workers <%= puma_workers %>
+<% if fetch(:puma_worker_timeout) %>
+worker_timeout <%= fetch(:puma_worker_timeout).to_i %>
+<% end %>
+
+<% if puma_daemonize? %>
+daemonize
+<% end %>
+
+<% if puma_preload_app? %>
+preload_app!
+<% else %>
+prune_bundler
+<% end %>
+
+on_restart do
+  puts 'Refreshing Gemfile'
+  ENV["BUNDLE_GEMFILE"] = "<%= fetch(:bundle_gemfile, "#{current_path}/Gemfile") %>"
+end
+
+<% if puma_preload_app? and fetch(:puma_init_active_record) %>
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect!
+end
+
+on_worker_boot do
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Base.establish_connection
+  end
+end
+<% end %>


### PR DESCRIPTION
Changes to deployment to give better control over running/restarting the app.

Runs the app as it's own user, so it can be started, stopped and restarted without root privileges. Also installed the capistrano3-puma plugin, so app can be restarted directly from developer machine.

Restart the app after deployment with the following command:

    bundle exec cap production puma:restart