### PR TITLE
Fix production config to know we're running under a suburl.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,6 +25,9 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Deploy to suburl
+  config.action_controller.relative_url_root = '/trvguit'
+
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
This should fix the asset paths in precompiled javascript and stylesheets.